### PR TITLE
Fixed dynamic linking to HDF5 on Windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
         - clang.patch  # [osx]
         - prepend-dll.patch  # [win]
         - MSC_VER_1900_snprintf.patch  # [win]
+        - windowshdf5.patch  # [win]
         - install_scripts.patch
 
 build:

--- a/recipe/windowshdf5.patch
+++ b/recipe/windowshdf5.patch
@@ -1,0 +1,11 @@
+--- frmts\hdf5\makefile_orig.vc	2016-01-25 23:03:48.000000000 +1000
++++ frmts\hdf5\makefile.vc	2016-06-03 10:15:30.498546900 +1000
+@@ -7,7 +7,7 @@
+ 
+ PLUGIN_DLL 	=	gdal_HDF5.dll
+ 
+-EXTRAFLAGS 	= 	-I$(HDF5_DIR)\include -DWIN32 -D_HDF5USEDLL_ 
++EXTRAFLAGS 	= 	-I$(HDF5_DIR)\include -DWIN32 -DH5_BUILT_AS_DYNAMIC_LIB 
+ 
+ !IF "$(HDF5_PLUGIN)" == "YES"
+ EXTRAFLAGS = $(EXTRAFLAGS) -DHDF5_PLUGIN


### PR DESCRIPTION
Seems necessary to do this with latest HDF5. See https://trac.osgeo.org/gdal/wiki/HDF#BuildingonWindowswithMSVC
